### PR TITLE
Add automatic state management for sorties

### DIFF
--- a/.idea/ENI-Sortir.com.iml
+++ b/.idea/ENI-Sortir.com.iml
@@ -135,6 +135,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/doctrine/data-fixtures" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/doctrine/doctrine-fixtures-bundle" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfonycasts/tailwind-bundle" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/twig/intl-extra" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -153,6 +153,7 @@
       <path value="$PROJECT_DIR$/vendor/doctrine/data-fixtures" />
       <path value="$PROJECT_DIR$/vendor/doctrine/doctrine-fixtures-bundle" />
       <path value="$PROJECT_DIR$/vendor/symfonycasts/tailwind-bundle" />
+      <path value="$PROJECT_DIR$/vendor/twig/intl-extra" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="8.2">

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "symfony/yaml": "7.3.*",
         "symfonycasts/tailwind-bundle": "^0.11.1",
         "twig/extra-bundle": "^2.12|^3.21",
+        "twig/intl-extra": "^3.21",
         "twig/twig": "^2.12|^3.21.1"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bee18fb26e5911e286d52c4c63f277ae",
+    "content-hash": "8fcc8c3b8d63981daed32248af71b881",
     "packages": [
         {
             "name": "composer/semver",
@@ -7856,6 +7856,70 @@
                 }
             ],
             "time": "2025-02-19T14:29:33+00:00"
+        },
+        {
+            "name": "twig/intl-extra",
+            "version": "v3.21.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/intl-extra.git",
+                "reference": "05bc5d46b9df9e62399eae53e7c0b0633298b146"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/intl-extra/zipball/05bc5d46b9df9e62399eae53e7c0b0633298b146",
+                "reference": "05bc5d46b9df9e62399eae53e7c0b0633298b146",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1.0",
+                "symfony/intl": "^5.4|^6.4|^7.0",
+                "twig/twig": "^3.13|^4.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Twig\\Extra\\Intl\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "A Twig extension for Intl",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "intl",
+                "twig"
+            ],
+            "support": {
+                "source": "https://github.com/twigphp/intl-extra/tree/v3.21.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-01-31T20:45:36+00:00"
         },
         {
             "name": "twig/twig",

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -44,6 +44,7 @@ security:
         - { path: ^/register, roles: PUBLIC_ACCESS }
         - { path: ^/logout, roles: PUBLIC_ACCESS }
         - { path: ^/sorties, roles: PUBLIC_ACCESS }
+        - { path: ^/sortie/, roles: PUBLIC_ACCESS }
         - { path: ^/$, roles: PUBLIC_ACCESS }
         - { path: ^/, roles: ROLE_USER }
 

--- a/config/packages/translation.yaml
+++ b/config/packages/translation.yaml
@@ -1,5 +1,5 @@
 framework:
-    default_locale: en
+    default_locale: fr
     translator:
         default_path: '%kernel.project_dir%/translations'
         providers:

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -1,5 +1,7 @@
 twig:
     file_name_pattern: '*.twig'
+    date:
+        timezone: 'Europe/Paris'
 
 when@test:
     twig:

--- a/migrations/Version20250925125450.php
+++ b/migrations/Version20250925125450.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250925125450 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE etat (id INT AUTO_INCREMENT NOT NULL, libelle VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE lieu (id INT AUTO_INCREMENT NOT NULL, id_ville_id INT DEFAULT NULL, nom VARCHAR(255) NOT NULL, rue VARCHAR(255) NOT NULL, latitude DOUBLE PRECISION NOT NULL, longitude DOUBLE PRECISION NOT NULL, INDEX IDX_2F577D59F7E4ECA3 (id_ville_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE participant (id INT AUTO_INCREMENT NOT NULL, id_site_id INT DEFAULT NULL, mail VARCHAR(180) NOT NULL, roles JSON NOT NULL, password VARCHAR(255) NOT NULL, nom VARCHAR(255) NOT NULL, prenom VARCHAR(255) NOT NULL, telephone VARCHAR(255) NOT NULL, is_administrateur TINYINT(1) NOT NULL, is_actif TINYINT(1) NOT NULL, pseudo VARCHAR(255) NOT NULL, INDEX IDX_D79F6B112820BF36 (id_site_id), UNIQUE INDEX UNIQ_IDENTIFIER_MAIL (mail), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE site (id INT AUTO_INCREMENT NOT NULL, nom VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sortie (id INT AUTO_INCREMENT NOT NULL, id_site_id INT DEFAULT NULL, id_lieu_id INT DEFAULT NULL, etat_id INT DEFAULT NULL, id_organisateur_id INT DEFAULT NULL, nom VARCHAR(255) NOT NULL, date_heure_debut DATETIME NOT NULL, duree INT NOT NULL, date_limite_inscription DATETIME NOT NULL, nb_inscription_max INT NOT NULL, infos_sortie VARCHAR(255) NOT NULL, is_archived TINYINT(1) DEFAULT NULL, archived_at DATETIME DEFAULT NULL, INDEX IDX_3C3FD3F22820BF36 (id_site_id), INDEX IDX_3C3FD3F2B42FBABC (id_lieu_id), INDEX IDX_3C3FD3F2D5E86FF (etat_id), INDEX IDX_3C3FD3F230687172 (id_organisateur_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sortie_participant (sortie_id INT NOT NULL, participant_id INT NOT NULL, INDEX IDX_E6D4CDADCC72D953 (sortie_id), INDEX IDX_E6D4CDAD9D1C3019 (participant_id), PRIMARY KEY(sortie_id, participant_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE ville (id INT AUTO_INCREMENT NOT NULL, nom VARCHAR(255) NOT NULL, code_postal VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE messenger_messages (id BIGINT AUTO_INCREMENT NOT NULL, body LONGTEXT NOT NULL, headers LONGTEXT NOT NULL, queue_name VARCHAR(190) NOT NULL, created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', available_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', delivered_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX IDX_75EA56E0FB7336F0 (queue_name), INDEX IDX_75EA56E0E3BD61CE (available_at), INDEX IDX_75EA56E016BA31DB (delivered_at), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE lieu ADD CONSTRAINT FK_2F577D59F7E4ECA3 FOREIGN KEY (id_ville_id) REFERENCES ville (id)');
+        $this->addSql('ALTER TABLE participant ADD CONSTRAINT FK_D79F6B112820BF36 FOREIGN KEY (id_site_id) REFERENCES site (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F22820BF36 FOREIGN KEY (id_site_id) REFERENCES site (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F2B42FBABC FOREIGN KEY (id_lieu_id) REFERENCES lieu (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F2D5E86FF FOREIGN KEY (etat_id) REFERENCES etat (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F230687172 FOREIGN KEY (id_organisateur_id) REFERENCES participant (id)');
+        $this->addSql('ALTER TABLE sortie_participant ADD CONSTRAINT FK_E6D4CDADCC72D953 FOREIGN KEY (sortie_id) REFERENCES sortie (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sortie_participant ADD CONSTRAINT FK_E6D4CDAD9D1C3019 FOREIGN KEY (participant_id) REFERENCES participant (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE lieu DROP FOREIGN KEY FK_2F577D59F7E4ECA3');
+        $this->addSql('ALTER TABLE participant DROP FOREIGN KEY FK_D79F6B112820BF36');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F22820BF36');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F2B42FBABC');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F2D5E86FF');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F230687172');
+        $this->addSql('ALTER TABLE sortie_participant DROP FOREIGN KEY FK_E6D4CDADCC72D953');
+        $this->addSql('ALTER TABLE sortie_participant DROP FOREIGN KEY FK_E6D4CDAD9D1C3019');
+        $this->addSql('DROP TABLE etat');
+        $this->addSql('DROP TABLE lieu');
+        $this->addSql('DROP TABLE participant');
+        $this->addSql('DROP TABLE site');
+        $this->addSql('DROP TABLE sortie');
+        $this->addSql('DROP TABLE sortie_participant');
+        $this->addSql('DROP TABLE ville');
+        $this->addSql('DROP TABLE messenger_messages');
+    }
+}

--- a/migrations/Version20250925125651.php
+++ b/migrations/Version20250925125651.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250925125651 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE etat (id INT AUTO_INCREMENT NOT NULL, libelle VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE lieu (id INT AUTO_INCREMENT NOT NULL, id_ville_id INT DEFAULT NULL, nom VARCHAR(255) NOT NULL, rue VARCHAR(255) NOT NULL, latitude DOUBLE PRECISION NOT NULL, longitude DOUBLE PRECISION NOT NULL, INDEX IDX_2F577D59F7E4ECA3 (id_ville_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE participant (id INT AUTO_INCREMENT NOT NULL, id_site_id INT DEFAULT NULL, mail VARCHAR(180) NOT NULL, roles JSON NOT NULL, password VARCHAR(255) NOT NULL, nom VARCHAR(255) NOT NULL, prenom VARCHAR(255) NOT NULL, telephone VARCHAR(255) NOT NULL, is_administrateur TINYINT(1) NOT NULL, is_actif TINYINT(1) NOT NULL, pseudo VARCHAR(255) NOT NULL, INDEX IDX_D79F6B112820BF36 (id_site_id), UNIQUE INDEX UNIQ_IDENTIFIER_MAIL (mail), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE site (id INT AUTO_INCREMENT NOT NULL, nom VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sortie (id INT AUTO_INCREMENT NOT NULL, id_site_id INT DEFAULT NULL, id_lieu_id INT DEFAULT NULL, etat_id INT DEFAULT NULL, id_organisateur_id INT DEFAULT NULL, nom VARCHAR(255) NOT NULL, date_heure_debut DATETIME NOT NULL, duree INT NOT NULL, date_limite_inscription DATETIME NOT NULL, nb_inscription_max INT NOT NULL, infos_sortie VARCHAR(255) NOT NULL, is_archived TINYINT(1) DEFAULT NULL, archived_at DATETIME DEFAULT NULL, INDEX IDX_3C3FD3F22820BF36 (id_site_id), INDEX IDX_3C3FD3F2B42FBABC (id_lieu_id), INDEX IDX_3C3FD3F2D5E86FF (etat_id), INDEX IDX_3C3FD3F230687172 (id_organisateur_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sortie_participant (sortie_id INT NOT NULL, participant_id INT NOT NULL, INDEX IDX_E6D4CDADCC72D953 (sortie_id), INDEX IDX_E6D4CDAD9D1C3019 (participant_id), PRIMARY KEY(sortie_id, participant_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE ville (id INT AUTO_INCREMENT NOT NULL, nom VARCHAR(255) NOT NULL, code_postal VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE messenger_messages (id BIGINT AUTO_INCREMENT NOT NULL, body LONGTEXT NOT NULL, headers LONGTEXT NOT NULL, queue_name VARCHAR(190) NOT NULL, created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', available_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', delivered_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX IDX_75EA56E0FB7336F0 (queue_name), INDEX IDX_75EA56E0E3BD61CE (available_at), INDEX IDX_75EA56E016BA31DB (delivered_at), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE lieu ADD CONSTRAINT FK_2F577D59F7E4ECA3 FOREIGN KEY (id_ville_id) REFERENCES ville (id)');
+        $this->addSql('ALTER TABLE participant ADD CONSTRAINT FK_D79F6B112820BF36 FOREIGN KEY (id_site_id) REFERENCES site (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F22820BF36 FOREIGN KEY (id_site_id) REFERENCES site (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F2B42FBABC FOREIGN KEY (id_lieu_id) REFERENCES lieu (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F2D5E86FF FOREIGN KEY (etat_id) REFERENCES etat (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F230687172 FOREIGN KEY (id_organisateur_id) REFERENCES participant (id)');
+        $this->addSql('ALTER TABLE sortie_participant ADD CONSTRAINT FK_E6D4CDADCC72D953 FOREIGN KEY (sortie_id) REFERENCES sortie (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sortie_participant ADD CONSTRAINT FK_E6D4CDAD9D1C3019 FOREIGN KEY (participant_id) REFERENCES participant (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE lieu DROP FOREIGN KEY FK_2F577D59F7E4ECA3');
+        $this->addSql('ALTER TABLE participant DROP FOREIGN KEY FK_D79F6B112820BF36');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F22820BF36');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F2B42FBABC');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F2D5E86FF');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F230687172');
+        $this->addSql('ALTER TABLE sortie_participant DROP FOREIGN KEY FK_E6D4CDADCC72D953');
+        $this->addSql('ALTER TABLE sortie_participant DROP FOREIGN KEY FK_E6D4CDAD9D1C3019');
+        $this->addSql('DROP TABLE etat');
+        $this->addSql('DROP TABLE lieu');
+        $this->addSql('DROP TABLE participant');
+        $this->addSql('DROP TABLE site');
+        $this->addSql('DROP TABLE sortie');
+        $this->addSql('DROP TABLE sortie_participant');
+        $this->addSql('DROP TABLE ville');
+        $this->addSql('DROP TABLE messenger_messages');
+    }
+}

--- a/migrations/Version20250925130434.php
+++ b/migrations/Version20250925130434.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250925130434 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE etat (id INT AUTO_INCREMENT NOT NULL, libelle VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE lieu (id INT AUTO_INCREMENT NOT NULL, id_ville_id INT DEFAULT NULL, nom VARCHAR(255) NOT NULL, rue VARCHAR(255) NOT NULL, latitude DOUBLE PRECISION NOT NULL, longitude DOUBLE PRECISION NOT NULL, INDEX IDX_2F577D59F7E4ECA3 (id_ville_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE participant (id INT AUTO_INCREMENT NOT NULL, id_site_id INT DEFAULT NULL, mail VARCHAR(180) NOT NULL, roles JSON NOT NULL, password VARCHAR(255) NOT NULL, nom VARCHAR(255) NOT NULL, prenom VARCHAR(255) NOT NULL, telephone VARCHAR(255) NOT NULL, is_administrateur TINYINT(1) NOT NULL, is_actif TINYINT(1) NOT NULL, pseudo VARCHAR(255) NOT NULL, INDEX IDX_D79F6B112820BF36 (id_site_id), UNIQUE INDEX UNIQ_IDENTIFIER_MAIL (mail), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE site (id INT AUTO_INCREMENT NOT NULL, nom VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sortie (id INT AUTO_INCREMENT NOT NULL, id_site_id INT DEFAULT NULL, id_lieu_id INT DEFAULT NULL, etat_id INT DEFAULT NULL, id_organisateur_id INT DEFAULT NULL, nom VARCHAR(255) NOT NULL, date_heure_debut DATETIME NOT NULL, duree INT NOT NULL, date_limite_inscription DATETIME NOT NULL, nb_inscription_max INT NOT NULL, infos_sortie VARCHAR(255) NOT NULL, is_archived TINYINT(1) DEFAULT NULL, archived_at DATETIME DEFAULT NULL, INDEX IDX_3C3FD3F22820BF36 (id_site_id), INDEX IDX_3C3FD3F2B42FBABC (id_lieu_id), INDEX IDX_3C3FD3F2D5E86FF (etat_id), INDEX IDX_3C3FD3F230687172 (id_organisateur_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sortie_participant (sortie_id INT NOT NULL, participant_id INT NOT NULL, INDEX IDX_E6D4CDADCC72D953 (sortie_id), INDEX IDX_E6D4CDAD9D1C3019 (participant_id), PRIMARY KEY(sortie_id, participant_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE ville (id INT AUTO_INCREMENT NOT NULL, nom VARCHAR(255) NOT NULL, code_postal VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE messenger_messages (id BIGINT AUTO_INCREMENT NOT NULL, body LONGTEXT NOT NULL, headers LONGTEXT NOT NULL, queue_name VARCHAR(190) NOT NULL, created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', available_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', delivered_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX IDX_75EA56E0FB7336F0 (queue_name), INDEX IDX_75EA56E0E3BD61CE (available_at), INDEX IDX_75EA56E016BA31DB (delivered_at), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE lieu ADD CONSTRAINT FK_2F577D59F7E4ECA3 FOREIGN KEY (id_ville_id) REFERENCES ville (id)');
+        $this->addSql('ALTER TABLE participant ADD CONSTRAINT FK_D79F6B112820BF36 FOREIGN KEY (id_site_id) REFERENCES site (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F22820BF36 FOREIGN KEY (id_site_id) REFERENCES site (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F2B42FBABC FOREIGN KEY (id_lieu_id) REFERENCES lieu (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F2D5E86FF FOREIGN KEY (etat_id) REFERENCES etat (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F230687172 FOREIGN KEY (id_organisateur_id) REFERENCES participant (id)');
+        $this->addSql('ALTER TABLE sortie_participant ADD CONSTRAINT FK_E6D4CDADCC72D953 FOREIGN KEY (sortie_id) REFERENCES sortie (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sortie_participant ADD CONSTRAINT FK_E6D4CDAD9D1C3019 FOREIGN KEY (participant_id) REFERENCES participant (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE lieu DROP FOREIGN KEY FK_2F577D59F7E4ECA3');
+        $this->addSql('ALTER TABLE participant DROP FOREIGN KEY FK_D79F6B112820BF36');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F22820BF36');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F2B42FBABC');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F2D5E86FF');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F230687172');
+        $this->addSql('ALTER TABLE sortie_participant DROP FOREIGN KEY FK_E6D4CDADCC72D953');
+        $this->addSql('ALTER TABLE sortie_participant DROP FOREIGN KEY FK_E6D4CDAD9D1C3019');
+        $this->addSql('DROP TABLE etat');
+        $this->addSql('DROP TABLE lieu');
+        $this->addSql('DROP TABLE participant');
+        $this->addSql('DROP TABLE site');
+        $this->addSql('DROP TABLE sortie');
+        $this->addSql('DROP TABLE sortie_participant');
+        $this->addSql('DROP TABLE ville');
+        $this->addSql('DROP TABLE messenger_messages');
+    }
+}

--- a/migrations/Version20250925130611.php
+++ b/migrations/Version20250925130611.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250925130611 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE etat (id INT AUTO_INCREMENT NOT NULL, libelle VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE lieu (id INT AUTO_INCREMENT NOT NULL, id_ville_id INT DEFAULT NULL, nom VARCHAR(255) NOT NULL, rue VARCHAR(255) NOT NULL, latitude DOUBLE PRECISION NOT NULL, longitude DOUBLE PRECISION NOT NULL, INDEX IDX_2F577D59F7E4ECA3 (id_ville_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE participant (id INT AUTO_INCREMENT NOT NULL, id_site_id INT DEFAULT NULL, mail VARCHAR(180) NOT NULL, roles JSON NOT NULL, password VARCHAR(255) NOT NULL, nom VARCHAR(255) NOT NULL, prenom VARCHAR(255) NOT NULL, telephone VARCHAR(255) NOT NULL, is_administrateur TINYINT(1) NOT NULL, is_actif TINYINT(1) NOT NULL, pseudo VARCHAR(255) NOT NULL, INDEX IDX_D79F6B112820BF36 (id_site_id), UNIQUE INDEX UNIQ_IDENTIFIER_MAIL (mail), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE site (id INT AUTO_INCREMENT NOT NULL, nom VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sortie (id INT AUTO_INCREMENT NOT NULL, id_site_id INT DEFAULT NULL, id_lieu_id INT DEFAULT NULL, etat_id INT DEFAULT NULL, id_organisateur_id INT DEFAULT NULL, nom VARCHAR(255) NOT NULL, date_heure_debut DATETIME NOT NULL, duree INT NOT NULL, date_limite_inscription DATETIME NOT NULL, nb_inscription_max INT NOT NULL, infos_sortie VARCHAR(255) NOT NULL, is_archived TINYINT(1) DEFAULT NULL, archived_at DATETIME DEFAULT NULL, INDEX IDX_3C3FD3F22820BF36 (id_site_id), INDEX IDX_3C3FD3F2B42FBABC (id_lieu_id), INDEX IDX_3C3FD3F2D5E86FF (etat_id), INDEX IDX_3C3FD3F230687172 (id_organisateur_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sortie_participant (sortie_id INT NOT NULL, participant_id INT NOT NULL, INDEX IDX_E6D4CDADCC72D953 (sortie_id), INDEX IDX_E6D4CDAD9D1C3019 (participant_id), PRIMARY KEY(sortie_id, participant_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE ville (id INT AUTO_INCREMENT NOT NULL, nom VARCHAR(255) NOT NULL, code_postal VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE messenger_messages (id BIGINT AUTO_INCREMENT NOT NULL, body LONGTEXT NOT NULL, headers LONGTEXT NOT NULL, queue_name VARCHAR(190) NOT NULL, created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', available_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', delivered_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX IDX_75EA56E0FB7336F0 (queue_name), INDEX IDX_75EA56E0E3BD61CE (available_at), INDEX IDX_75EA56E016BA31DB (delivered_at), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE lieu ADD CONSTRAINT FK_2F577D59F7E4ECA3 FOREIGN KEY (id_ville_id) REFERENCES ville (id)');
+        $this->addSql('ALTER TABLE participant ADD CONSTRAINT FK_D79F6B112820BF36 FOREIGN KEY (id_site_id) REFERENCES site (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F22820BF36 FOREIGN KEY (id_site_id) REFERENCES site (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F2B42FBABC FOREIGN KEY (id_lieu_id) REFERENCES lieu (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F2D5E86FF FOREIGN KEY (etat_id) REFERENCES etat (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F230687172 FOREIGN KEY (id_organisateur_id) REFERENCES participant (id)');
+        $this->addSql('ALTER TABLE sortie_participant ADD CONSTRAINT FK_E6D4CDADCC72D953 FOREIGN KEY (sortie_id) REFERENCES sortie (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sortie_participant ADD CONSTRAINT FK_E6D4CDAD9D1C3019 FOREIGN KEY (participant_id) REFERENCES participant (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE lieu DROP FOREIGN KEY FK_2F577D59F7E4ECA3');
+        $this->addSql('ALTER TABLE participant DROP FOREIGN KEY FK_D79F6B112820BF36');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F22820BF36');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F2B42FBABC');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F2D5E86FF');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F230687172');
+        $this->addSql('ALTER TABLE sortie_participant DROP FOREIGN KEY FK_E6D4CDADCC72D953');
+        $this->addSql('ALTER TABLE sortie_participant DROP FOREIGN KEY FK_E6D4CDAD9D1C3019');
+        $this->addSql('DROP TABLE etat');
+        $this->addSql('DROP TABLE lieu');
+        $this->addSql('DROP TABLE participant');
+        $this->addSql('DROP TABLE site');
+        $this->addSql('DROP TABLE sortie');
+        $this->addSql('DROP TABLE sortie_participant');
+        $this->addSql('DROP TABLE ville');
+        $this->addSql('DROP TABLE messenger_messages');
+    }
+}

--- a/migrations/Version20250925130834.php
+++ b/migrations/Version20250925130834.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250925130834 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE etat (id INT AUTO_INCREMENT NOT NULL, libelle VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE lieu (id INT AUTO_INCREMENT NOT NULL, id_ville_id INT DEFAULT NULL, nom VARCHAR(255) NOT NULL, rue VARCHAR(255) NOT NULL, latitude DOUBLE PRECISION NOT NULL, longitude DOUBLE PRECISION NOT NULL, INDEX IDX_2F577D59F7E4ECA3 (id_ville_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE participant (id INT AUTO_INCREMENT NOT NULL, id_site_id INT DEFAULT NULL, mail VARCHAR(180) NOT NULL, roles JSON NOT NULL, password VARCHAR(255) NOT NULL, nom VARCHAR(255) NOT NULL, prenom VARCHAR(255) NOT NULL, telephone VARCHAR(255) NOT NULL, is_administrateur TINYINT(1) NOT NULL, is_actif TINYINT(1) NOT NULL, pseudo VARCHAR(255) NOT NULL, INDEX IDX_D79F6B112820BF36 (id_site_id), UNIQUE INDEX UNIQ_IDENTIFIER_MAIL (mail), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE site (id INT AUTO_INCREMENT NOT NULL, nom VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sortie (id INT AUTO_INCREMENT NOT NULL, id_site_id INT DEFAULT NULL, id_lieu_id INT DEFAULT NULL, etat_id INT DEFAULT NULL, id_organisateur_id INT DEFAULT NULL, nom VARCHAR(255) NOT NULL, date_heure_debut DATETIME NOT NULL, duree INT NOT NULL, date_limite_inscription DATETIME NOT NULL, nb_inscription_max INT NOT NULL, infos_sortie VARCHAR(255) NOT NULL, is_archived TINYINT(1) DEFAULT NULL, archived_at DATETIME DEFAULT NULL, INDEX IDX_3C3FD3F22820BF36 (id_site_id), INDEX IDX_3C3FD3F2B42FBABC (id_lieu_id), INDEX IDX_3C3FD3F2D5E86FF (etat_id), INDEX IDX_3C3FD3F230687172 (id_organisateur_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sortie_participant (sortie_id INT NOT NULL, participant_id INT NOT NULL, INDEX IDX_E6D4CDADCC72D953 (sortie_id), INDEX IDX_E6D4CDAD9D1C3019 (participant_id), PRIMARY KEY(sortie_id, participant_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE ville (id INT AUTO_INCREMENT NOT NULL, nom VARCHAR(255) NOT NULL, code_postal VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE messenger_messages (id BIGINT AUTO_INCREMENT NOT NULL, body LONGTEXT NOT NULL, headers LONGTEXT NOT NULL, queue_name VARCHAR(190) NOT NULL, created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', available_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', delivered_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX IDX_75EA56E0FB7336F0 (queue_name), INDEX IDX_75EA56E0E3BD61CE (available_at), INDEX IDX_75EA56E016BA31DB (delivered_at), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE lieu ADD CONSTRAINT FK_2F577D59F7E4ECA3 FOREIGN KEY (id_ville_id) REFERENCES ville (id)');
+        $this->addSql('ALTER TABLE participant ADD CONSTRAINT FK_D79F6B112820BF36 FOREIGN KEY (id_site_id) REFERENCES site (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F22820BF36 FOREIGN KEY (id_site_id) REFERENCES site (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F2B42FBABC FOREIGN KEY (id_lieu_id) REFERENCES lieu (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F2D5E86FF FOREIGN KEY (etat_id) REFERENCES etat (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F230687172 FOREIGN KEY (id_organisateur_id) REFERENCES participant (id)');
+        $this->addSql('ALTER TABLE sortie_participant ADD CONSTRAINT FK_E6D4CDADCC72D953 FOREIGN KEY (sortie_id) REFERENCES sortie (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sortie_participant ADD CONSTRAINT FK_E6D4CDAD9D1C3019 FOREIGN KEY (participant_id) REFERENCES participant (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE lieu DROP FOREIGN KEY FK_2F577D59F7E4ECA3');
+        $this->addSql('ALTER TABLE participant DROP FOREIGN KEY FK_D79F6B112820BF36');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F22820BF36');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F2B42FBABC');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F2D5E86FF');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F230687172');
+        $this->addSql('ALTER TABLE sortie_participant DROP FOREIGN KEY FK_E6D4CDADCC72D953');
+        $this->addSql('ALTER TABLE sortie_participant DROP FOREIGN KEY FK_E6D4CDAD9D1C3019');
+        $this->addSql('DROP TABLE etat');
+        $this->addSql('DROP TABLE lieu');
+        $this->addSql('DROP TABLE participant');
+        $this->addSql('DROP TABLE site');
+        $this->addSql('DROP TABLE sortie');
+        $this->addSql('DROP TABLE sortie_participant');
+        $this->addSql('DROP TABLE ville');
+        $this->addSql('DROP TABLE messenger_messages');
+    }
+}

--- a/migrations/Version20250925132043.php
+++ b/migrations/Version20250925132043.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250925132043 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE etat (id INT AUTO_INCREMENT NOT NULL, libelle VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE lieu (id INT AUTO_INCREMENT NOT NULL, id_ville_id INT DEFAULT NULL, nom VARCHAR(255) NOT NULL, rue VARCHAR(255) NOT NULL, latitude DOUBLE PRECISION NOT NULL, longitude DOUBLE PRECISION NOT NULL, INDEX IDX_2F577D59F7E4ECA3 (id_ville_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE participant (id INT AUTO_INCREMENT NOT NULL, id_site_id INT DEFAULT NULL, mail VARCHAR(180) NOT NULL, roles JSON NOT NULL, password VARCHAR(255) NOT NULL, nom VARCHAR(255) NOT NULL, prenom VARCHAR(255) NOT NULL, telephone VARCHAR(255) NOT NULL, is_administrateur TINYINT(1) NOT NULL, is_actif TINYINT(1) NOT NULL, pseudo VARCHAR(255) NOT NULL, INDEX IDX_D79F6B112820BF36 (id_site_id), UNIQUE INDEX UNIQ_IDENTIFIER_MAIL (mail), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE site (id INT AUTO_INCREMENT NOT NULL, nom VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sortie (id INT AUTO_INCREMENT NOT NULL, id_site_id INT DEFAULT NULL, id_lieu_id INT DEFAULT NULL, etat_id INT DEFAULT NULL, id_organisateur_id INT DEFAULT NULL, nom VARCHAR(255) NOT NULL, date_heure_debut DATETIME NOT NULL, duree INT NOT NULL, date_limite_inscription DATETIME NOT NULL, nb_inscription_max INT NOT NULL, infos_sortie VARCHAR(255) NOT NULL, is_archived TINYINT(1) DEFAULT NULL, archived_at DATETIME DEFAULT NULL, INDEX IDX_3C3FD3F22820BF36 (id_site_id), INDEX IDX_3C3FD3F2B42FBABC (id_lieu_id), INDEX IDX_3C3FD3F2D5E86FF (etat_id), INDEX IDX_3C3FD3F230687172 (id_organisateur_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sortie_participant (sortie_id INT NOT NULL, participant_id INT NOT NULL, INDEX IDX_E6D4CDADCC72D953 (sortie_id), INDEX IDX_E6D4CDAD9D1C3019 (participant_id), PRIMARY KEY(sortie_id, participant_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE ville (id INT AUTO_INCREMENT NOT NULL, nom VARCHAR(255) NOT NULL, code_postal VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE messenger_messages (id BIGINT AUTO_INCREMENT NOT NULL, body LONGTEXT NOT NULL, headers LONGTEXT NOT NULL, queue_name VARCHAR(190) NOT NULL, created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', available_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', delivered_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX IDX_75EA56E0FB7336F0 (queue_name), INDEX IDX_75EA56E0E3BD61CE (available_at), INDEX IDX_75EA56E016BA31DB (delivered_at), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE lieu ADD CONSTRAINT FK_2F577D59F7E4ECA3 FOREIGN KEY (id_ville_id) REFERENCES ville (id)');
+        $this->addSql('ALTER TABLE participant ADD CONSTRAINT FK_D79F6B112820BF36 FOREIGN KEY (id_site_id) REFERENCES site (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F22820BF36 FOREIGN KEY (id_site_id) REFERENCES site (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F2B42FBABC FOREIGN KEY (id_lieu_id) REFERENCES lieu (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F2D5E86FF FOREIGN KEY (etat_id) REFERENCES etat (id)');
+        $this->addSql('ALTER TABLE sortie ADD CONSTRAINT FK_3C3FD3F230687172 FOREIGN KEY (id_organisateur_id) REFERENCES participant (id)');
+        $this->addSql('ALTER TABLE sortie_participant ADD CONSTRAINT FK_E6D4CDADCC72D953 FOREIGN KEY (sortie_id) REFERENCES sortie (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sortie_participant ADD CONSTRAINT FK_E6D4CDAD9D1C3019 FOREIGN KEY (participant_id) REFERENCES participant (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE lieu DROP FOREIGN KEY FK_2F577D59F7E4ECA3');
+        $this->addSql('ALTER TABLE participant DROP FOREIGN KEY FK_D79F6B112820BF36');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F22820BF36');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F2B42FBABC');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F2D5E86FF');
+        $this->addSql('ALTER TABLE sortie DROP FOREIGN KEY FK_3C3FD3F230687172');
+        $this->addSql('ALTER TABLE sortie_participant DROP FOREIGN KEY FK_E6D4CDADCC72D953');
+        $this->addSql('ALTER TABLE sortie_participant DROP FOREIGN KEY FK_E6D4CDAD9D1C3019');
+        $this->addSql('DROP TABLE etat');
+        $this->addSql('DROP TABLE lieu');
+        $this->addSql('DROP TABLE participant');
+        $this->addSql('DROP TABLE site');
+        $this->addSql('DROP TABLE sortie');
+        $this->addSql('DROP TABLE sortie_participant');
+        $this->addSql('DROP TABLE ville');
+        $this->addSql('DROP TABLE messenger_messages');
+    }
+}

--- a/src/DataFixtures/data_game.sql
+++ b/src/DataFixtures/data_game.sql
@@ -5,7 +5,8 @@ INSERT INTO ville (id, nom, code_postal) VALUES
  (1, 'Saint-Herblain', '44800'),
  (2, 'Rennes', '35000'),
  (3, 'Niort', '79000'),
- (4, 'Laval', '53000');
+ (4, 'Laval', '53000'),
+ (5, 'Nantes', '44000');
 
 -- ========================
 -- TABLE : LIEU
@@ -25,7 +26,10 @@ INSERT INTO lieu (id, nom, rue, latitude, longitude, id_ville_id) VALUES
 
 -- Laval
 (7, 'Château de Laval', 'Place de la Trémoille', 48.0717, -0.7716, 4),
-(8, 'Stade Francis Le Basser', 'Rue Paul Lintier', 48.0831, -0.7603, 4);
+(8, 'Stade Francis Le Basser', 'Rue Paul Lintier', 48.0831, -0.7603, 4),
+
+-- Nantes
+(9, 'Stade de la Beaujoire', 'Avenue de la gare Saint Joseph', 46.3246, -0.4631, 5);
 
 -- ========================
 -- TABLE : SITE
@@ -34,19 +38,18 @@ INSERT INTO site (id, nom) VALUES
 (1, 'Site Saint-Herblain'),
 (2, 'Site Rennes'),
 (3, 'Site Niort'),
-(4, 'Site Laval');
+(4, 'Site Laval'),
+(5, 'Site Nantes');
 
 -- ========================
 -- TABLE : ETAT
 -- ========================
 INSERT INTO etat (id, libelle) VALUES
-(1, 'Créée'),
-(2, 'Ouverte'),
-(3, 'Clôturée'),
-(4, 'Activité en cours'),
-(5, 'Terminée'),
-(6, 'Annulée'),
-(7, 'Archivée');
+(1, 'Ouvert'),
+(2, 'En cours'),
+(3, 'En création'),
+(4, 'Fermée'),
+(5, 'Terminée');
 
 -- ========================
 -- TABLE : PARTICIPANT
@@ -56,6 +59,9 @@ INSERT INTO participant (id, mail, roles, password, nom, prenom, telephone, is_a
 (12, 'benoit.herblain@mail.com', '["ROLE_USER"]', '$2y$13$0WF4KSBahl.MreCj.ihXIe8USt/j1X3ArmoafV4bR1WafWZ5Mbw0C', 'Martin', 'Benoît', '0622222222', false, true, 1, 'Ben44'),
 (13, 'chloe.rennes@mail.com', '["ROLE_USER"]', '$2y$13$0WF4KSBahl.MreCj.ihXIe8USt/j1X3ArmoafV4bR1WafWZ5Mbw0C', 'Durand', 'Chloé', '0633333333', false, true, 2, 'Chlo35'),
 (4, 'david.rennes@mail.com', '["ROLE_USER"]', '$2y$13$0WF4KSBahl.MreCj.ihXIe8USt/j1X3ArmoafV4bR1WafWZ5Mbw0C', 'Lemoine', 'David', '0644444444', false, true, 2, 'Dave35'),
+(1, 'cloe@gmail.com', '["ADMIN"]', '$2y$13$0WF4KSBahl.MreCj.ihXIe8USt/j1X3ArmoafV4bR1WafWZ5Mbw0C', 'Lemarechal', 'Cloe', '0644444444', true, true, 1, 'CloeCDA'),
+(2, 'lucas@gmail.com', '["ADMIN"]', '$2y$13$0WF4KSBahl.MreCj.ihXIe8USt/j1X3ArmoafV4bR1WafWZ5Mbw0C', 'Guerin', 'Lucas', '0644444444', true, true, 1, 'LucasCDA'),
+(3, 'aime@gmail.com', '["ADMIN"]', '$2y$13$0WF4KSBahl.MreCj.ihXIe8USt/j1X3ArmoafV4bR1WafWZ5Mbw0C', 'Chaigneau', 'Aime', '0644444444', true, true, 1, 'AimeCDA'),
 (5, 'emma.niort@mail.com', '["ROLE_USER"]', '$2y$13$0WF4KSBahl.MreCj.ihXIe8USt/j1X3ArmoafV4bR1WafWZ5Mbw0C', 'Bernard', 'Emma', '0655555555', false, true, 3, 'Emma79'),
 (6, 'francois.niort@mail.com', '["ROLE_USER"]', '$2y$13$0WF4KSBahl.MreCj.ihXIe8USt/j1X3ArmoafV4bR1WafWZ5Mbw0C', 'Moreau', 'François', '0666666666', false, true, 3, 'Fran79'),
 (7, 'isabelle.laval@mail.com', '["ROLE_USER"]', '$2y$13$0WF4KSBahl.MreCj.ihXIe8USt/j1X3ArmoafV4bR1WafWZ5Mbw0C', 'Petit', 'Isabelle', '0677777777', false, true, 4, 'Isa53'),
@@ -67,14 +73,22 @@ INSERT INTO participant (id, mail, roles, password, nom, prenom, telephone, is_a
 -- TABLE : SORTIE
 -- ========================
 INSERT INTO sortie (id, nom, date_heure_debut, duree, date_limite_inscription, nb_inscription_max, infos_sortie, id_site_id, id_lieu_id, etat_id, id_organisateur_id, is_archived, archived_at) VALUES
-(1, 'Concert au Zénith', '2025-06-20 20:00:00', 180, '2025-06-15 23:59:59', 100, 'Concert rock à Saint-Herblain', 1, 1, 2, 1, false, NULL),
-(2, 'Shopping Atlantis', '2025-05-12 14:00:00', 120, '2025-05-10 23:59:59', 30, 'Après-midi shopping au centre Atlantis', 1, 2, 1, 2, false, NULL),
-(3, 'Balade au Thabor', '2025-05-18 10:00:00', 90, '2025-05-15 23:59:59', 20, 'Promenade printanière', 2, 3, 2, 3, false, NULL),
-(4, 'Match au Roazhon Park', '2025-07-05 21:00:00', 120, '2025-07-01 23:59:59', 50, 'Match de Ligue 1', 2, 4, 2, 4, false, NULL),
-(5, 'Visite du Donjon', '2025-06-10 15:00:00', 60, '2025-06-08 23:59:59', 15, 'Découverte du patrimoine historique', 3, 5, 1, 5, false, NULL),
-(6, 'Foot au Stade René Gaillard', '2025-06-25 19:00:00', 90, '2025-06-20 23:59:59', 22, 'Petit match amical entre amis', 3, 6, 2, 6, false, NULL),
-(7, 'Visite du Château de Laval', '2025-07-12 14:00:00', 120, '2025-07-08 23:59:59', 25, 'Visite guidée du château', 4, 7, 2, 7, false, NULL),
-(8, 'Match au Stade Francis Le Basser', '2025-08-01 20:00:00', 120, '2025-07-25 23:59:59', 40, 'Match de Ligue 2', 4, 8, 2, 8, false, NULL);
+(1, 'Concert au Zénith', '2025-06-20 20:00:00', 180, '2025-06-15 23:59:59', 100, 'Concert rock à Saint-Herblain', 1, 1, 5, 1, false, NULL), -- Terminée mais non archivée
+(2, 'Shopping Atlantis', '2025-05-12 14:00:00', 120, '2025-05-10 23:59:59', 30, 'Après-midi shopping au centre Atlantis', 1, 2, 5, 2, false, NULL), -- Terminée mais non archivée
+(3, 'Balade au Thabor', '2025-05-18 10:00:00', 90, '2025-05-15 23:59:59', 20, 'Promenade printanière', 2, 3, 5, 3, false, NULL), -- Terminée mais non archivée
+(4, 'Match au Roazhon Park', '2025-07-05 21:00:00', 120, '2025-07-01 23:59:59', 50, 'Match de Ligue 1', 2, 4, 5, 4, true, '2025-07-06 00:00:00'), -- Terminée et archivée (exemple)
+(5, 'Visite du Donjon', '2025-06-10 15:00:00', 60, '2025-06-08 23:59:59', 15, 'Découverte du patrimoine historique', 3, 5, 5, 5, false, NULL), -- Terminée mais non archivée
+(6, 'Foot au Stade René Gaillard', '2025-06-25 19:00:00', 90, '2025-06-20 23:59:59', 22, 'Petit match amical entre amis', 3, 6, 5, 6, false, NULL), -- Terminée mais non archivée
+(7, 'Visite du Château de Laval', '2025-07-12 14:00:00', 120, '2025-07-08 23:59:59', 25, 'Visite guidée du château', 4, 7, 4, 7, false, NULL), -- Fermée
+(8, 'Match au Stade Francis Le Basser', '2025-08-01 20:00:00', 120, '2025-07-25 23:59:59', 40, 'Match de Ligue 2', 4, 8, 2, 8, false, NULL), -- Ouvert
+(9, 'Match au Stade de la Beaujoire', '2025-09-20 17:00:00', 120, '2025-09-01 23:59:59', 40, 'Match de Ligue 1 Nantes-Rennes', 5, 9, 1, 2, false, NULL), -- Ouvert
+(10, 'Soirée jeux de société', '2025-10-15 18:30:00', 180, '2025-10-10 23:59:59', 12, 'Soirée conviviale avec jeux de société', 1, 1, 1, 1, false, NULL), -- Ouvert
+(11, 'Randonnée en forêt', '2025-10-22 09:00:00', 240, '2025-10-18 23:59:59', 15, 'Randonnée en forêt de Rennes', 2, 3, 1, 3, false, NULL), -- Ouvert
+(12, 'Atelier cuisine', '2025-11-05 17:00:00', 180, '2025-10-30 23:59:59', 8, 'Atelier cuisine italienne', 3, 5, 1, 5, false, NULL), -- Ouvert
+(13, 'Concert jazz', '2025-11-10 20:30:00', 120, '2025-11-05 23:59:59', 30, 'Concert jazz au Zénith', 1, 1, 1, 1, false, NULL), -- Ouvert
+(14, 'Tournoi de tennis', '2025-11-20 14:00:00', 240, '2025-11-15 23:59:59', 16, 'Tournoi amical de tennis', 4, 8, 1, 7, false, NULL), -- Ouvert
+(15, 'Soirée cinéma', '2025-12-05 20:00:00', 180, '2025-11-30 23:59:59', 20, 'Projection de films indépendants', 2, 3, 1, 3, false, NULL), -- Ouvert
+(16, 'Festival des lumières', '2025-12-20 18:00:00', 360, '2025-12-15 23:59:59', 100, 'Festival hivernal avec illuminations', 5, 9, 3, 2, false, NULL); -- En création
 
 -- ========================
 -- TABLE : SORTIE_PARTICIPANT (ManyToMany)

--- a/src/Form/SortieType.php
+++ b/src/Form/SortieType.php
@@ -30,27 +30,30 @@ class SortieType extends AbstractType
             ])
             ->add('nbInscriptionMax', IntegerType::class)
             ->add('infosSortie', TextType::class)
-//            ->add('idSite', EntityType::class, [
-//                'class' => Site::class,
-//                'choice_label' => 'nom',
-//            ])
-//            ->add('idLieu', EntityType::class, [
-//                'class' => Lieu::class,
-//                'choice_label' => 'nom',
-//            ])
-            ->add('etat', EntityType::class, [
-                'class' => Etat::class,
-                'choice_label' => 'libelle'
+            ->add('idSite', EntityType::class, [
+                'class' => Site::class,
+                'choice_label' => 'nom',
+            ])
+            ->add('idLieu', EntityType::class, [
+                'class' => Lieu::class,
+                'choice_label' => 'nom',
+            ])
+            ->add('rue', TextType::class, [
+                'mapped' => false,
+                'required' => false,
+            ])
+            ->add('latitude', TextType::class, [
+                'mapped' => false,
+                'required' => false,
+            ])
+            ->add('longitude', TextType::class, [
+                'mapped' => false,
+                'required' => false,
             ])
             ->add('idOrganisateur', EntityType::class, [
                 'class' => Participant::class,
                 'choice_label' => 'pseudo',
             ])
-//            ->add('participants', EntityType::class, [
-//                'class' => Participant::class,
-//                'choice_label' => 'id',
-//                'multiple' => true,
-//            ])
         ;
     }
 

--- a/templates/sortie/edit.html.twig
+++ b/templates/sortie/edit.html.twig
@@ -8,57 +8,55 @@
             <h1 class="text-2xl font-bold mb-6 text-center text-black">Modifier la sortie</h1>
 
             {{ form_start(form) }}
-            <div class="space-y-4">
-                {{ form_row(form.nom, {
-                    label: 'Nom',
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
 
-                {{ form_row(form.dateHeureDebut, {
-                    label: 'Date et heure de début',
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
+            {# Grille en deux colonnes #}
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
 
-                {{ form_row(form.duree, {
-                    label: 'Durée (minutes)',
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
+                {# --- COLONNE GAUCHE : infos générales --- #}
+                <div class="space-y-4">
+                    {{ form_row(form.nom, { label: 'Nom', label_attr: {'class': 'text-black'},
+                        attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
 
-                {{ form_row(form.dateLimiteInscription, {
-                    label: "Date limite d'inscription",
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
+                    {{ form_row(form.dateHeureDebut, { label: 'Date et heure de début', label_attr: {'class': 'text-black'},
+                        attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
 
-                {{ form_row(form.nbInscriptionMax, {
-                    label: "Nombre maximum d'inscriptions",
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
+                    {{ form_row(form.duree, { label: 'Durée (minutes)', label_attr: {'class': 'text-black'},
+                        attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
 
-                {{ form_row(form.infosSortie, {
-                    label: "Informations sur la sortie",
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
+                    {{ form_row(form.dateLimiteInscription, { label: "Date limite d'inscription", label_attr: {'class': 'text-black'},
+                        attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
 
-                {{ form_row(form.etat, {
-                    label: "État",
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
+                    {{ form_row(form.nbInscriptionMax, { label: "Nombre maximum d'inscriptions", label_attr: {'class': 'text-black'},
+                        attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
 
-                {{ form_row(form.idOrganisateur, {
-                    label: "Organisateur",
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
+                    {{ form_row(form.infosSortie, { label: "Informations sur la sortie", label_attr: {'class': 'text-black'},
+                        attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
+
+                    {{ form_row(form.idOrganisateur, { label: "Organisateur", label_attr: {'class': 'text-black'},
+                        attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
+                </div>
+
+                {# --- COLONNE DROITE : localisation --- #}
+                <div class="space-y-4">
+                    {{ form_row(form.idSite, { label: "Ville de la sortie", label_attr: {'class': 'text-black'},
+                        attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
+
+                    {{ form_row(form.idLieu, { label: "Lieu de la sortie", label_attr: {'class': 'text-black'},
+                        attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
+
+                    {{ form_row(form.rue, { label: "Rue", label_attr: {'class': 'text-black'},
+                        attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
+
+                    {{ form_row(form.latitude, { label: "Latitude", label_attr: {'class': 'text-black'},
+                        attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
+
+                    {{ form_row(form.longitude, { label: "Longitude", label_attr: {'class': 'text-black'},
+                        attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
+                </div>
             </div>
 
-            <div class="flex justify-between items-center mt-6">
+            {# Boutons en bas, centrés sur toute la largeur #}
+            <div class="flex justify-between items-center mt-8">
                 <button class="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-2 rounded-md transition duration-200">
                     Mettre à jour
                 </button>

--- a/templates/sortie/list.html.twig
+++ b/templates/sortie/list.html.twig
@@ -3,17 +3,17 @@
 {% block title %}Liste des sorties{% endblock %}
 
 {% block body %}
-    <div class="max-w-8xl mx-auto mt-10 px-6">
-        <div class="flex justify-between items-center mb-6">
+    <div class="max-w-8xl mx-auto mt-5 mb-10">
+        <div class="flex justify-between items-center mb-5">
             <h1 class="text-3xl font-bold text-gray-800">Liste des sorties</h1>
 
             {# Bouton de création de sortie uniquement si un user est connecté #}
             {% if app.user %}
-                <a href="{{ path('app_sortie_new') }}" class="focus:outline-none text-white bg-green-600 hover:bg-green-700 font-medium rounded-lg text-sm px-5 py-2.5 shadow">
+                <a href="{{ path('app_sortie_new') }}"
+                   class="focus:outline-none text-white bg-green-600 hover:bg-green-700 font-medium rounded-lg text-sm px-5 py-2.5 shadow">
                     <span>Créer une sortie </span>
                 </a>
             {% endif %}
-
         </div>
 
         {% if sorties is empty %}
@@ -25,113 +25,141 @@
 
                     {# Header du tableau avec les libellés des données #}
                     <thead class="bg-gray-100 text-gray-700 uppercase text-sm">
-                        <tr>
-                            <th class="px-4 py-3 text-left">Nom</th>
-                            <th class="px-4 py-3 text-left">Date du début</th>
-                            <th class="px-4 py-3 text-left">Cloture</th>
-                            <th class="px-4 py-3 text-left">Durée (min)</th>
-                            <th class="px-4 py-3 text-left">Lieu</th>
-                            <th class="px-4 py-3 text-left">Site</th>
-                            <th class="px-4 py-3 text-left">Infos</th>
-                            <th class="px-4 py-3 text-left">État</th>
-                            <th class="px-4 py-3 text-left">Organisateur</th>
-                            <th class="px-4 py-3 text-center">Actions</th>
-                        </tr>
+                    <tr>
+                        <th class="px-4 py-3 text-left">Nom</th>
+                        <th class="px-4 py-3 text-left">Date du début</th>
+                        <th class="px-4 py-3 text-left">Cloture</th>
+                        <th class="px-4 py-3 text-left">Durée (min)</th>
+                        <th class="px-4 py-3 text-left">Lieu</th>
+                        <th class="px-4 py-3 text-left">Site</th>
+                        <th class="px-4 py-3 text-left">Infos</th>
+                        <th class="px-4 py-3 text-left">Inscriptions</th>
+                        <th class="px-4 py-3 text-left">État</th>
+                        <th class="px-4 py-3 text-left">Organisateur</th>
+                        <th class="px-4 py-3 text-center">Actions</th>
+                    </tr>
                     </thead>
 
                     <tbody class="divide-y divide-gray-200 text-sm text-gray-800">
-                        {% for sortie in sorties %}
-                            <tr class="hover:bg-gray-100 {% if app.user and sortie.idOrganisateur == app.user %}bg-gray-50{% endif %}">
+                    {% for sortie in sorties %}
+                        <tr class="hover:bg-gray-100 {% if app.user and sortie.idOrganisateur == app.user %}bg-gray-50{% endif %}">
 
                             {# Affiche le détail de sortie si on clique sur le nom #}
-                                <td class="px-4 py-3">
-                                    <a href="{{ path('app_sortie_show', {id: sortie.id}) }}"
-                                       class="text-blue-600 hover:underline">
-                                        <span>{{ sortie.nom }}</span>
-                                    </a>
-                                </td>
+                            <td class="px-4 py-3">
+                                <a href="{{ path('app_sortie_show', {id: sortie.id}) }}"
+                                   class="text-blue-600 hover:underline">
+                                    <span>{{ sortie.nom }}</span>
+                                </a>
+                            </td>
 
-                                <td class="px-4 py-3">{{ sortie.dateHeureDebut ? sortie.dateHeureDebut|date('d/m/Y H:i') : '' }}</td>
-                                <td class="px-4 py-3">{{ sortie.dateLimiteInscription ? sortie.dateLimiteInscription|date('d/m/Y H:i') : '' }}</td>
-                                <td class="px-4 py-3">{{ sortie.duree }}</td>
-                                <td class="px-4 py-3">{{ sortie.idLieu ? sortie.idLieu.nom : '' }}</td>
-                                <td class="px-4 py-3">{{ sortie.idSite ? sortie.idSite.nom : '' }}</td>
-                                <td class="px-4 py-3">{{ sortie.infosSortie ? sortie.infosSortie : '' }}</td>
+                            <td class="px-4 py-3">
+                                {{ sortie.dateHeureDebut ? (sortie.dateHeureDebut|format_datetime(pattern="EEEE d MMMM y 'à' HH'h'mm", locale='fr')|capitalize) : '' }}
+                            </td>
+                            <td class="px-4 py-3">{{ sortie.dateLimiteInscription ? sortie.dateLimiteInscription|date('d/m/Y') : '' }}</td>
 
-                                {# Définit un code couleur de l'état en fonction de celui-ci #}
-                                <td class="px-4 py-3">
-                                    {% if sortie.etat %}
-                                        {% set etat = sortie.etat.libelle %}
-                                        {% set color = '' %}
 
-                                        {% if etat == 'Créé' %}
-                                            {% set color = 'bg-yellow-100 text-yellow-800' %}
-                                        {% elseif etat == 'Ouverte' %}
-                                            {% set color = 'bg-green-100 text-green-800' %}
-                                        {% elseif etat == 'Clôturée' %}
-                                            {% set color = 'bg-red-100 text-red-800' %}
-                                        {% elseif etat == 'Activité en cours' %}
-                                            {% set color = 'bg-orange-100 text-orange-800' %}
-                                        {% elseif etat == 'Terminée' %}
-                                            {% set color = 'bg-gray-300 text-gray-900' %}
-                                        {% elseif etat == 'Archivée' %}
-                                            {% set color = 'bg-gray-100 text-gray-700 italic' %}
-                                        {% else %}
-                                            {% set color = 'bg-gray-50 text-gray-800' %}
-                                        {% endif %}
+                            <td class="px-4 py-3">{{ sortie.duree }}</td>
+                            <td class="px-4 py-3">{{ sortie.idLieu ? sortie.idLieu.nom : '' }}</td>
+                            <td class="px-4 py-3">{{ sortie.idSite ? sortie.idSite.nom : '' }}</td>
+                            <td class="px-4 py-3">{{ sortie.infosSortie ? sortie.infosSortie : '' }}</td>
 
-                                        <span class="px-2 py-1 rounded-full text-xs font-semibold {{ color }}">
+                            <td class="px-4 py-3">
+                                {{ sortie.participants|length }}/{{ sortie.nbInscriptionMax }}
+                            </td>
+
+                            {# Définit un code couleur de l'état en fonction de celui-ci #}
+                            <td class="px-4 py-3">
+                                {% if sortie.etat %}
+                                    {% set etat = sortie.etat.libelle %}
+                                    {% set color = '' %}
+
+                                    {% if etat == 'Ouvert' %}
+                                        {% set color = 'bg-green-100 text-green-800' %}
+                                    {% elseif etat == 'En cours' %}
+                                        {% set color = 'bg-yellow-100 text-yellow-800' %}
+                                    {% elseif etat == 'En création' %}
+                                        {% set color = 'bg-orange-100 text-orange-800' %}
+                                    {% elseif etat == 'Fermée' %}
+                                        {% set color = 'bg-gray-100 text-gray-800' %}
+                                    {% elseif etat == 'Terminée' %}
+                                        {% set color = 'bg-red-100 text-red-800' %}
+                                    {% endif %}
+
+                                    <span class="px-2 py-1 rounded-full text-xs font-semibold {{ color }}">
                                             <span>{{ etat }}</span>
                                         </span>
-                                    {% endif %}
-                                </td>
+                                {% endif %}
+                            </td>
 
-                                <td class="px-4 py-3">
-                                    {{ sortie.idOrganisateur ? sortie.idOrganisateur.prenom : '' }} {{ sortie.idOrganisateur ? sortie.idOrganisateur.nom : '' }}
-                                </td>
+                            <td class="px-4 py-3">
+                                {{ sortie.idOrganisateur ? sortie.idOrganisateur.prenom : '' }} {{ sortie.idOrganisateur ? sortie.idOrganisateur.nom : '' }}
+                            </td>
 
-                                {# Action sur la sortie #}
-                                <td class="px-4 py-3 flex flex-col items-center gap-2">
+                            {# Action sur la sortie #}
+                            <td class="px-4 py-3 flex flex-col items-center gap-2">
 
-                                    {# Actions pour l'organisateur #}
-                                    {% if app.user and sortie.idOrganisateur == app.user %}
+                                {# Actions pour l'organisateur #}
+                                {% if app.user and sortie.idOrganisateur == app.user %}
+                                    {% if sortie.etat and sortie.etat.libelle == 'Ouvert' %}
                                         <a href="{{ path('app_sortie_edit', {id: sortie.id}) }}"
                                            class="w-32 text-center px-3 py-1.5 bg-green-800 text-white text-xs rounded hover:bg-blue-600">
                                             <span>Modifier</span>
                                         </a>
-
-                                        <form method="post" action="{{ path('app_sortie_archive', {id: sortie.id}) }}" onsubmit="return confirm('Voulez-vous vraiment archiver cette sortie ?');">
-                                            <input type="hidden" name="_token" value="{{ csrf_token('archive' ~ sortie.id) }}">
-                                            <button class="w-32 text-center px-3 py-1.5 bg-yellow-500 text-white text-xs rounded hover:bg-yellow-600">Archiver</button>
-                                        </form>
-
-                                        <form method="post" action="{{ path('app_sortie_delete', {id: sortie.id}) }}" onsubmit="return confirm('Êtes-vous sûr de vouloir annuler cette sortie ?');">
-                                            <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ sortie.id) }}">
-                                            <button class="w-32 text-center px-3 py-1.5 bg-red-600 text-white text-xs rounded hover:bg-red-700">Annuler</button>
-                                        </form>
                                     {% endif %}
 
-                                    {# Actions d'inscription/désinscription pour tout utilisateur connecté #}
-                                    {% if app.user and sortie.idOrganisateur != app.user %}
+                                    <form method="post" action="{{ path('app_sortie_archive', {id: sortie.id}) }}"
+                                          onsubmit="return confirm('Voulez-vous vraiment archiver cette sortie ?');">
+                                        <input type="hidden" name="_token"
+                                               value="{{ csrf_token('archive' ~ sortie.id) }}">
+                                        <button
+                                            class="w-32 text-center px-3 py-1.5 bg-yellow-500 text-white text-xs rounded hover:bg-yellow-600">
+                                            Archiver
+                                        </button>
+                                    </form>
+
+                                    {% if sortie.etat and (sortie.etat.libelle == 'Ouvert' or sortie.etat.libelle == 'En cours') %}
+                                        <form method="post" action="{{ path('app_sortie_delete', {id: sortie.id}) }}"
+                                              onsubmit="return confirm('Êtes-vous sûr de vouloir annuler cette sortie ?');">
+                                            <input type="hidden" name="_token"
+                                                   value="{{ csrf_token('delete' ~ sortie.id) }}">
+                                            <button
+                                                class="w-32 text-center px-3 py-1.5 bg-red-600 text-white text-xs rounded hover:bg-red-700">
+                                                Annuler
+                                            </button>
+                                        </form>
+                                    {% endif %}
+                                {% endif %}
+
+                                {# Actions d'inscription/désinscription pour tout utilisateur connecté #}
+                                {% if app.user and sortie.idOrganisateur != app.user %}
+                                    {% if sortie.etat and (sortie.etat.libelle == 'Ouvert' or sortie.etat.libelle == 'En création') %}
                                         {% if sortie.participants.contains(app.user) %}
-                                            <form method="post" action="{{ path('app_sortie_desinscription', {id: sortie.id}) }}">
-                                                <input type="hidden" name="_token" value="{{ csrf_token('desinscription' ~ sortie.id) }}">
-                                                <button class="w-32 text-center px-3 py-1.5 bg-blue-800 text-white text-xs rounded hover:bg-red-700">
+                                            <form method="post"
+                                                  action="{{ path('app_sortie_desinscription', {id: sortie.id}) }}">
+                                                <input type="hidden" name="_token"
+                                                       value="{{ csrf_token('desinscription' ~ sortie.id) }}">
+                                                <button
+                                                    class="w-32 text-center px-3 py-1.5 bg-blue-800 text-white text-xs rounded hover:bg-blue-900">
                                                     <span>Se désinscrire</span>
                                                 </button>
                                             </form>
                                         {% else %}
-                                            <form method="post" action="{{ path('app_sortie_inscription', {id: sortie.id}) }}">
-                                                <input type="hidden" name="_token" value="{{ csrf_token('inscription' ~ sortie.id) }}">
-                                                <button class="w-32 text-center px-3 py-1.5 bg-blue-400 text-white text-xs rounded hover:bg-green-700">
+                                            <form method="post"
+                                                  action="{{ path('app_sortie_inscription', {id: sortie.id}) }}">
+                                                <input type="hidden" name="_token"
+                                                       value="{{ csrf_token('inscription' ~ sortie.id) }}">
+                                                <button
+                                                    class="w-32 text-center px-3 py-1.5 bg-blue-400 text-white text-xs rounded hover:bg-blue-500">
                                                     <span>S'inscrire</span>
                                                 </button>
                                             </form>
                                         {% endif %}
                                     {% endif %}
-                                </td>
-                            </tr>
-                        {% endfor %}
+                                {% endif %}
+
+                            </td>
+                        </tr>
+                    {% endfor %}
                     </tbody>
 
                 </table>

--- a/templates/sortie/new.html.twig
+++ b/templates/sortie/new.html.twig
@@ -3,69 +3,67 @@
 {% block title %}Créer une sortie{% endblock %}
 
 {% block body %}
-    <div class="min-h-screen flex items-start justify-center pt-20">
-        <div class="w-full max-w-2xl shadow-lg rounded-xl p-8 bg-gray-50">
+    <div class="min-h-screen flex items-start justify-center">
+        <div class="w-full max-w-4xl shadow-lg rounded-xl p-8 bg-gray-50">
             <h1 class="text-2xl font-bold mb-6 text-center text-black">Créer une nouvelle sortie</h1>
 
             {{ form_start(form) }}
-            <div class="space-y-4">
-                {{ form_row(form.nom, {
-                    label: 'Nom',
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
 
-                {{ form_row(form.dateHeureDebut, {
-                    label: 'Date et heure de début',
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
+                {# Grille en deux colonnes #}
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
 
-                {{ form_row(form.duree, {
-                    label: 'Durée (minutes)',
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
+                    {# --- COLONNE GAUCHE : infos générales --- #}
+                    <div class="space-y-4">
+                        {{ form_row(form.nom, { label: 'Nom', label_attr: {'class': 'text-black'},
+                            attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
 
-                {{ form_row(form.dateLimiteInscription, {
-                    label: "Date limite d'inscription",
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
+                        {{ form_row(form.dateHeureDebut, { label: 'Date et heure de début', label_attr: {'class': 'text-black'},
+                            attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
 
-                {{ form_row(form.nbInscriptionMax, {
-                    label: "Nombre maximum d'inscriptions",
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
+                        {{ form_row(form.duree, { label: 'Durée (minutes)', label_attr: {'class': 'text-black'},
+                            attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
 
-                {{ form_row(form.infosSortie, {
-                    label: "Informations sur la sortie",
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
+                        {{ form_row(form.dateLimiteInscription, { label: "Date limite d'inscription", label_attr: {'class': 'text-black'},
+                            attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
 
-                {{ form_row(form.etat, {
-                    label: "État",
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
+                        {{ form_row(form.nbInscriptionMax, { label: "Nombre maximum d'inscriptions", label_attr: {'class': 'text-black'},
+                            attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
 
-                {{ form_row(form.idOrganisateur, {
-                    label: "Organisateur",
-                    label_attr: {'class': 'text-black'},
-                    attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'}
-                }) }}
-            </div>
+                        {{ form_row(form.infosSortie, { label: "Informations sur la sortie", label_attr: {'class': 'text-black'},
+                            attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
 
-            <div class="flex justify-between items-center mt-6">
-                <button class="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-2 rounded-md transition duration-200">
-                    Enregistrer
-                </button>
-                <a href="{{ path('app_sortie_list') }}" class="text-sm text-gray-600 hover:underline">
-                    Retour à la liste
-                </a>
-            </div>
+                        {{ form_row(form.idOrganisateur, { label: "Organisateur", label_attr: {'class': 'text-black'},
+                            attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
+                    </div>
+
+                    {# --- COLONNE DROITE : localisation --- #}
+                    <div class="space-y-4">
+                        {{ form_row(form.idSite, { label: "Ville de la sortie", label_attr: {'class': 'text-black'},
+                            attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
+
+                        {{ form_row(form.idLieu, { label: "Lieu de la sortie", label_attr: {'class': 'text-black'},
+                            attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
+
+                        {{ form_row(form.rue, { label: "Rue", label_attr: {'class': 'text-black'},
+                            attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
+
+                        {{ form_row(form.latitude, { label: "Latitude", label_attr: {'class': 'text-black'},
+                            attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
+
+                        {{ form_row(form.longitude, { label: "Longitude", label_attr: {'class': 'text-black'},
+                            attr: {'class': 'w-full px-4 py-2 border border-gray-300 rounded-md bg-white text-black'} }) }}
+                    </div>
+                </div>
+
+                {# Boutons en bas, centrés sur toute la largeur #}
+                <div class="flex justify-between items-center mt-8">
+                    <button class="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-2 rounded-md transition duration-200">
+                        Enregistrer
+                    </button>
+                    <a href="{{ path('app_sortie_list') }}" class="text-sm text-gray-600 hover:underline">
+                        Retour à la liste
+                    </a>
+                </div>
             {{ form_end(form) }}
         </div>
     </div>


### PR DESCRIPTION
Introduces automatic state calculation and updating for sorties in SortieController, ensuring the state is set based on current date and sortie properties. Adds a private updateEtat() method, updates list, show, new, and edit actions to use it, and restricts editing to 'Ouvert' sorties. Also updates security, translation, and Twig configs, adds twig/intl-extra dependency, and updates fixtures and migrations for new data and schema.